### PR TITLE
Fixed a 3D viewer crash for users with SDL2.dll in their PATH

### DIFF
--- a/Radegast/GUI/Rendering/Rendering.cs
+++ b/Radegast/GUI/Rendering/Rendering.cs
@@ -551,6 +551,13 @@ namespace Radegast.Rendering
         #region glControl setup and disposal
         public void SetupGLControl()
         {
+            // Crash fix for users with SDL2.dll in their path. OpenTK will attempt to use
+            //   SDL2 if it's available, but SDL2 is unsupported and will crash users.
+            OpenTK.Toolkit.Init(new OpenTK.ToolkitOptions
+            {
+                Backend = OpenTK.PlatformBackend.PreferNative
+            });
+
             RenderingEnabled = false;
 
             glControl?.Dispose();


### PR DESCRIPTION
* SDL2.dll: https://www.libsdl.org/download-2.0.php
* See: https://github.com/opentk/opentk/issues/266