### PR TITLE
Lsl helper allowed owner refactoring

### DIFF
--- a/Radegast/Automation/LSLHelper.cs
+++ b/Radegast/Automation/LSLHelper.cs
@@ -38,7 +38,7 @@ namespace Radegast.Automation
     public class LSLHelper : IDisposable
     {
         public bool Enabled;
-        public HashSet<String> AllowedOwner;
+        public HashSet<String> AllowedOwners;
 
         RadegastInstance instance;
         GridClient client => instance.Client;
@@ -46,7 +46,7 @@ namespace Radegast.Automation
         public LSLHelper(RadegastInstance instance)
         {
             this.instance = instance;
-            this.AllowedOwner = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            this.AllowedOwners = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
 
         public void Dispose()
@@ -62,7 +62,7 @@ namespace Radegast.Automation
                     return;
                 OSDMap map = (OSDMap)instance.ClientSettings["LSLHelper"];
                 Enabled = map["enabled"];
-                AllowedOwner.UnionWith(map["allowed_owner"].AsString().Split(';'));
+                AllowedOwners.UnionWith(map["allowed_owner"].AsString().Split(';'));
             }
             catch { }
         }
@@ -74,7 +74,7 @@ namespace Radegast.Automation
             {
                 OSDMap map = new OSDMap(2);
                 map["enabled"] = Enabled;
-                map["allowed_owner"] = string.Join(";", AllowedOwner);
+                map["allowed_owner"] = string.Join(";", AllowedOwners);
                 instance.ClientSettings["LSLHelper"] = map;
             }
             catch { }
@@ -98,7 +98,7 @@ namespace Radegast.Automation
             {
                 case InstantMessageDialog.MessageFromObject:
                     {
-                        if (!AllowedOwner.Contains(e.IM.FromAgentID.ToString()))
+                        if (!AllowedOwners.Contains(e.IM.FromAgentID.ToString()))
                         {
                             return true;
                         }

--- a/Radegast/Automation/LSLHelper.cs
+++ b/Radegast/Automation/LSLHelper.cs
@@ -62,11 +62,7 @@ namespace Radegast.Automation
                     return;
                 OSDMap map = (OSDMap)instance.ClientSettings["LSLHelper"];
                 Enabled = map["enabled"];
-                AllowedOwner.Clear();
-                foreach (String AllowedOwnner in map["allowed_owner"].AsString().Split(';'))
-                {
-                    AllowedOwner.Add(AllowedOwnner);
-                }
+                AllowedOwner = new List<string>(map["allowed_owner"].AsString().Split(';'));
             }
             catch { }
         }
@@ -76,18 +72,9 @@ namespace Radegast.Automation
             if (!client.Network.Connected) return;
             try
             {
-                String AllowedOwnner = "";
                 OSDMap map = new OSDMap(2);
                 map["enabled"] = Enabled;
-                for (int i = 0; i < AllowedOwner.Count; i++)
-                {
-                    if (i > 0)
-                    {
-                        AllowedOwnner += ";";
-                    }
-                    AllowedOwnner += AllowedOwner.ToArray()[i];
-                }
-                map["allowed_owner"] = AllowedOwnner;
+                map["allowed_owner"] = string.Join(";", AllowedOwner);
                 instance.ClientSettings["LSLHelper"] = map;
             }
             catch { }

--- a/Radegast/Automation/LSLHelper.cs
+++ b/Radegast/Automation/LSLHelper.cs
@@ -63,7 +63,11 @@ namespace Radegast.Automation
                 OSDMap map = (OSDMap)instance.ClientSettings["LSLHelper"];
                 Enabled = map["enabled"];
                 AllowedOwners.Clear();
-                AllowedOwners.UnionWith(map["allowed_owner"].AsString().Split(';'));
+                var allowedOwnerList = map["allowed_owner"].AsString();
+                if (!string.IsNullOrWhiteSpace(allowedOwnerList))
+                {
+                    AllowedOwners.UnionWith(allowedOwnerList.Split(';'));
+                }
             }
             catch { }
         }

--- a/Radegast/Automation/LSLHelper.cs
+++ b/Radegast/Automation/LSLHelper.cs
@@ -62,6 +62,7 @@ namespace Radegast.Automation
                     return;
                 OSDMap map = (OSDMap)instance.ClientSettings["LSLHelper"];
                 Enabled = map["enabled"];
+                AllowedOwners.Clear();
                 AllowedOwners.UnionWith(map["allowed_owner"].AsString().Split(';'));
             }
             catch { }

--- a/Radegast/Automation/LSLHelper.cs
+++ b/Radegast/Automation/LSLHelper.cs
@@ -38,7 +38,7 @@ namespace Radegast.Automation
     public class LSLHelper : IDisposable
     {
         public bool Enabled;
-        public List<String> AllowedOwner;
+        public HashSet<String> AllowedOwner;
 
         RadegastInstance instance;
         GridClient client => instance.Client;
@@ -46,7 +46,7 @@ namespace Radegast.Automation
         public LSLHelper(RadegastInstance instance)
         {
             this.instance = instance;
-            this.AllowedOwner = new List<string>();
+            this.AllowedOwner = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
 
         public void Dispose()
@@ -62,7 +62,7 @@ namespace Radegast.Automation
                     return;
                 OSDMap map = (OSDMap)instance.ClientSettings["LSLHelper"];
                 Enabled = map["enabled"];
-                AllowedOwner = new List<string>(map["allowed_owner"].AsString().Split(';'));
+                AllowedOwner.UnionWith(map["allowed_owner"].AsString().Split(';'));
             }
             catch { }
         }
@@ -98,7 +98,7 @@ namespace Radegast.Automation
             {
                 case InstantMessageDialog.MessageFromObject:
                     {
-                        if (AllowedOwner.IndexOf(e.IM.FromAgentID.ToString()) == -1)
+                        if (!AllowedOwner.Contains(e.IM.FromAgentID.ToString()))
                         {
                             return true;
                         }

--- a/Radegast/GUI/Dialogs/Settings.Designer.cs
+++ b/Radegast/GUI/Dialogs/Settings.Designer.cs
@@ -1269,6 +1269,7 @@ namespace Radegast
             this.tbpChat.ResumeLayout(false);
             this.tbpChat.PerformLayout();
             this.ResumeLayout(false);
+            this.FormClosing += FrmSettings_FormClosing;
 
         }
 

--- a/Radegast/GUI/Dialogs/Settings.cs
+++ b/Radegast/GUI/Dialogs/Settings.cs
@@ -724,16 +724,7 @@ namespace Radegast
             }
 
             Instance.State.LSLHelper.LoadSettings();
-            String AllowedOwnner = "";
-            for (int i = 0; Instance.State.LSLHelper.AllowedOwner != null && i < Instance.State.LSLHelper.AllowedOwner.Count; i++)
-            {
-                if (i > 0)
-                {
-                    AllowedOwnner += "\r\n";
-                }
-                AllowedOwnner += Instance.State.LSLHelper.AllowedOwner.ToArray()[i];
-            }
-            tbLSLAllowedOwner.Text = AllowedOwnner;
+            tbLSLAllowedOwner.Text = string.Join(Environment.NewLine, Instance.State.LSLHelper.AllowedOwner);
             cbLSLHelperEnabled.CheckedChanged -=new EventHandler(cbLSLHelperEnabled_CheckedChanged);
             cbLSLHelperEnabled.Checked = Instance.State.LSLHelper.Enabled;
             cbLSLHelperEnabled.CheckedChanged += new EventHandler(cbLSLHelperEnabled_CheckedChanged);
@@ -748,14 +739,18 @@ namespace Radegast
 
             Instance.State.LSLHelper.Enabled = cbLSLHelperEnabled.Checked;
             Instance.State.LSLHelper.AllowedOwner.Clear();
-            if (tbLSLAllowedOwner.Text.Trim().Length > 0)
+            foreach (var line in tbLSLAllowedOwner.Lines)
             {
-                foreach (String AllowedOwnner in tbLSLAllowedOwner.Lines)
+                if (!string.IsNullOrWhiteSpace(line))
                 {
-                    if (AllowedOwnner.Trim().Length > 0)
+                    if (!UUID.TryParse(line, out _))
                     {
-                        Instance.State.LSLHelper.AllowedOwner.Add(AllowedOwnner.Trim());
+                        MessageBox.Show($"Invalid owner UUID: {line}", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                        Instance.State.LSLHelper.AllowedOwner.Clear();
+                        break;
                     }
+
+                    Instance.State.LSLHelper.AllowedOwner.Add(line.Trim().ToLower());
                 }
             }
             Instance.State.LSLHelper.SaveSettings();
@@ -768,17 +763,6 @@ namespace Radegast
 
         private void tbLSLAllowedOwner_Leave(object sender, EventArgs e)
         {
-            Instance.State.LSLHelper.AllowedOwner.Clear();
-            if (tbLSLAllowedOwner.Text.Trim().Length > 0)
-            {
-                foreach (String AllowedOwnner in tbLSLAllowedOwner.Lines)
-                {
-                    if (AllowedOwnner.Trim().Length > 0)
-                    {
-                        Instance.State.LSLHelper.AllowedOwner.Add(AllowedOwnner.Trim());
-                    }
-                }
-            }
             LSLHelperPrefsSave();
         }
 

--- a/Radegast/GUI/Dialogs/Settings.cs
+++ b/Radegast/GUI/Dialogs/Settings.cs
@@ -32,6 +32,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Text;
 using System.Windows.Forms;
 
 using OpenMetaverse;
@@ -739,21 +740,32 @@ namespace Radegast
 
             Instance.State.LSLHelper.Enabled = cbLSLHelperEnabled.Checked;
             Instance.State.LSLHelper.AllowedOwner.Clear();
+
+            var warnings = new StringBuilder();
             foreach (var line in tbLSLAllowedOwner.Lines)
             {
-                if (!string.IsNullOrWhiteSpace(line))
+                if (string.IsNullOrWhiteSpace(line))
                 {
-                    if (!UUID.TryParse(line, out _))
-                    {
-                        MessageBox.Show($"Invalid owner UUID: {line}", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                        Instance.State.LSLHelper.AllowedOwner.Clear();
-                        break;
-                    }
+                    continue;
+                }
 
-                    Instance.State.LSLHelper.AllowedOwner.Add(line.Trim().ToLower());
+                var owner = line.Trim().ToLower();
+                if (!UUID.TryParse(owner, out _))
+                {
+                    warnings.AppendLine($"Invalid owner UUID: {line}");
+                }
+                else
+                {
+                    Instance.State.LSLHelper.AllowedOwner.Add(owner);
                 }
             }
+            if (warnings.Length > 0)
+            {
+                MessageBox.Show(warnings.ToString(), "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
+
             Instance.State.LSLHelper.SaveSettings();
+            LSLHelperPrefsUpdate();
         }
 
         private void llLSLHelperInstructios_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)

--- a/Radegast/GUI/Dialogs/Settings.cs
+++ b/Radegast/GUI/Dialogs/Settings.cs
@@ -725,7 +725,7 @@ namespace Radegast
             }
 
             Instance.State.LSLHelper.LoadSettings();
-            tbLSLAllowedOwner.Text = string.Join(Environment.NewLine, Instance.State.LSLHelper.AllowedOwner);
+            tbLSLAllowedOwner.Text = string.Join(Environment.NewLine, Instance.State.LSLHelper.AllowedOwners);
             cbLSLHelperEnabled.CheckedChanged -=new EventHandler(cbLSLHelperEnabled_CheckedChanged);
             cbLSLHelperEnabled.Checked = Instance.State.LSLHelper.Enabled;
             cbLSLHelperEnabled.CheckedChanged += new EventHandler(cbLSLHelperEnabled_CheckedChanged);
@@ -739,7 +739,7 @@ namespace Radegast
             }
 
             Instance.State.LSLHelper.Enabled = cbLSLHelperEnabled.Checked;
-            Instance.State.LSLHelper.AllowedOwner.Clear();
+            Instance.State.LSLHelper.AllowedOwners.Clear();
 
             var warnings = new StringBuilder();
             foreach (var line in tbLSLAllowedOwner.Lines)
@@ -756,7 +756,7 @@ namespace Radegast
                 }
                 else
                 {
-                    Instance.State.LSLHelper.AllowedOwner.Add(owner);
+                    Instance.State.LSLHelper.AllowedOwners.Add(owner);
                 }
             }
             if (warnings.Length > 0)

--- a/Radegast/GUI/Dialogs/Settings.cs
+++ b/Radegast/GUI/Dialogs/Settings.cs
@@ -1034,6 +1034,11 @@ namespace Radegast
                 ResetFontSettings();
             }
         }
+
+        private void FrmSettings_FormClosing(object sender, System.Windows.Forms.FormClosingEventArgs e)
+        {
+            LSLHelperPrefsSave();
+        }
     }
 
 


### PR DESCRIPTION
* Very minor refactoring of AllowedOwner logic mainly to finally get rid of the old misspelled 'AllowedOwnner'
* Using case insensitive hashset to store and lookup owner uuids. 
* Duplicate and invalid UUIDs are removed from the owners list and a warning is presented if invalid UUIDs are detected
* Renamed AllowedOwner to AllowedOwners. Not renaming "allowed_owner" setting to preserve backwards compatibility
* LSLHelper Settings are saved when the settings window is closed. This is needed because it's very possible to edit the owner list and directly close the settings box, which will not trigger the 'leave' evet that is currently used to save the owners list.