### PR TITLE
[WIP] Remove LSLHelper commands dealing with money

### DIFF
--- a/Radegast/Automation/LSLHelper.cs
+++ b/Radegast/Automation/LSLHelper.cs
@@ -160,28 +160,6 @@ namespace Radegast.Automation
                                     );
                                     return true;
                                 }
-                            case "send_money":
-                                {
-                                    if (args.Length < 3) return true;
-                                    UUID sendTo = UUID.Zero;
-                                    if (!UUID.TryParse(args[1].Trim(), out sendTo)) return false;
-                                    int amount = 0;
-                                    if (int.TryParse(args[2].Trim(), out amount))
-                                    {
-                                        if (amount > client.Self.Balance) amount = client.Self.Balance;
-                                        client.Self.GiveAvatarMoney(sendTo, amount);
-                                    }
-                                    return true;
-                                }
-                            case "tell_balance":
-                                {
-                                    if (args.Length < 2) return true;
-                                    UUID sendTo = UUID.Zero;
-                                    if (!UUID.TryParse(args[1].Trim(), out sendTo)) return false;
-                                    string msg = String.Format("Hello, I have {0} L$ in my pocket.", client.Self.Balance);
-                                    client.Self.InstantMessage(sendTo, msg);
-                                    return true;
-                                }
                             case "say": /* This one doesn't work yet. I don't know why. TODO. - Nico */
                                 {
                                     if (args.Length < 2) return true;


### PR DESCRIPTION
While the intention is good, send_money is a massive security risk for existing users of LSLHelper. You can't just have critical permissions like this sneak into an existing system. It also opens up the possibility of exploitation via potential flaws in future code and through means of social engineering. There's already existing functionality with a permissions system in LSL for sending money via http://wiki.secondlife.com/wiki/LlTransferLindenDollars 

tell_balance - I'm not too sure about what use this would have without the send_money command and am kind of on the fence about if it should be removed. While very mild, this command may reveal information existing users of LSLHelper may not want to expose

