### PR TITLE
Fix custom login location

### DIFF
--- a/Radegast/Netcom/RadegastNetcom/NetCom.cs
+++ b/Radegast/Netcom/RadegastNetcom/NetCom.cs
@@ -249,6 +249,7 @@ namespace Radegast.Netcom
             }
 
             string startLocation = string.Empty;
+            string loginLocation = string.Empty;
 
             switch (loginOptions.StartLocation)
             {
@@ -256,10 +257,9 @@ namespace Radegast.Netcom
                 case StartLocationType.Last: startLocation = "last"; break;
 
                 case StartLocationType.Custom:
-                    startLocation = loginOptions.StartLocationCustom.Trim();
-
-                    StartLocationParser parser = new StartLocationParser(startLocation);
-                    startLocation = NetworkManager.StartLocation(parser.Sim, parser.X, parser.Y, parser.Z);
+                    StartLocationParser parser = new StartLocationParser(loginOptions.StartLocationCustom.Trim());
+                    startLocation = "last";
+                    loginLocation = $"{parser.Sim}/{parser.X}/{parser.Y}/{parser.Z}";
 
                     break;
             }
@@ -288,6 +288,7 @@ namespace Radegast.Netcom
 
             Grid = loginOptions.Grid;
             loginParams.Start = startLocation;
+            loginParams.LoginLocation = loginLocation;
             loginParams.AgreeToTos = AgreeToTos;
             loginParams.URI = Grid.LoginURI;
             loginParams.LastExecEvent = loginOptions.LastExecEvent;


### PR DESCRIPTION
Radegast currently ignores custom login locations and only accepts 'home' or 'last'. This now utilizes the required LoginLocation parameter introduced in https://github.com/cinderblocks/libremetaverse/pull/33

As a side note, I set startLocation to 'last' when using a custom login location to prevent LibreMetaverse from logging "The Start option only accepts home or last! please use LoginLocation to set a custom login location" every time you login.

*Alternatively*, we can take another look at the changes in https://github.com/cinderblocks/libremetaverse/pull/33 and make them backwards compatible with current clients that are using LibreMetaverse, which might be the better approach