### PR TITLE
Fix interests tab overwriting our own interests whenever we view profiles

### DIFF
--- a/Radegast/GUI/Dialogs/Profile.cs
+++ b/Radegast/GUI/Dialogs/Profile.cs
@@ -752,6 +752,11 @@ namespace Radegast
 
         private void interestsUpdated(object sender, EventArgs e)
         {
+            if (AgentID != client.Self.AgentID)
+            {
+                return;
+            }
+
             uint wantto = ((checkBoxBuild.Checked ? 1u << 0 : 0u)
                             | (checkBoxExplore.Checked ? 1u << 1 : 0u)
                             | (checkBoxMeet.Checked ? 1u << 2 : 0u)


### PR DESCRIPTION
Fixes the issue where Radegast will overwrite our interests whenever we open the interests tab of another user. interestsUpdated is being called whenever any of the controls on the interest tab is changed, which happens whenever we open the tab for any user, causing radegast to update our interests whenever we view another user's profile.

See:
https://radegast.life/bugs/radegast-is-changing-the-contents-of-my-profile-interests-tab/#comment-223878

