### PR TITLE
Don't sit on something different if RLV unsit restriction is set.

### DIFF
--- a/Radegast/Core/StateManager.cs
+++ b/Radegast/Core/StateManager.cs
@@ -888,23 +888,23 @@ namespace Radegast
         {
             sitting = sit;
 
-            if (sitting)
+            if (!instance.RLV.RestictionActive("unsit"))
             {
-                Client.Self.RequestSit(target, Vector3.Zero);
-                Client.Self.Sit();
-            }
-            else
-            {
-                if (!instance.RLV.RestictionActive("unsit"))
+                if (sitting)
                 {
-                    Client.Self.Stand();
+                    Client.Self.RequestSit(target, Vector3.Zero);
+                    Client.Self.Sit();
                 }
                 else
                 {
-                    instance.TabConsole.DisplayNotificationInChat("Unsit prevented by RLV");
-                    sitting = true;
-                    return;
+                    Client.Self.Stand();
                 }
+            }
+            else
+            {
+                instance.TabConsole.DisplayNotificationInChat("Unsit prevented by RLV");
+                sitting = true;
+                return;
             }
 
             SitStateChanged?.Invoke(this, new SitEventArgs(sitting));


### PR DESCRIPTION
The current Radegast operates differently from Firestorm with respect to the RLV `unsit` restriction.

Setup: Sit on an object with the RLV `unsit` restriction active. Have a second object do an RLV `@sit:<uuid>=force` .

Firestorm refuses to sit on the second object.
Radegast will move to the second object.

The RLV specification (under Sitting) specifies that `@sit:<uuid>=force` will not work if the avatar is prevented from unsitting.