### PR TITLE
Fixed login character hash. OpenMetaverse.Utils.MD5 is deprecated.

### DIFF
--- a/Radegast/GUI/Consoles/LoginConsole.cs
+++ b/Radegast/GUI/Consoles/LoginConsole.cs
@@ -148,7 +148,7 @@ namespace Radegast
                 }
                 else
                 {
-                    var passwd = Utils.MD5(passTxt.Length > 16 
+                    var passwd = RadegastUtils.Utils.MD5(passTxt.Length > 16
                         ? passTxt.Substring(0, 16) : passTxt);
                     savedLogin.Password = passwd;
                     globalSettings["password"] = passwd;

--- a/Radegast/Netcom/RadegastNetcom/NetCom.cs
+++ b/Radegast/Netcom/RadegastNetcom/NetCom.cs
@@ -265,8 +265,8 @@ namespace Radegast
             }
             else
             {
-                password = Utils.MD5(loginOptions.Password.Length > 16
-                    ? loginOptions.Password.Substring(0, 16) 
+                password = RadegastUtils.Utils.MD5(loginOptions.Password.Length > 16
+                    ? loginOptions.Password.Substring(0, 16)
                     : loginOptions.Password);
             }
 

--- a/Radegast/RadegastUtils/Utils.cs
+++ b/Radegast/RadegastUtils/Utils.cs
@@ -1,0 +1,16 @@
+﻿using System.Linq;
+using System.Text;
+
+namespace Radegast.RadegastUtils
+{
+    public static class Utils
+    {
+        public static string MD5(string input)
+        {
+            using (var md5 = System.Security.Cryptography.MD5.Create())
+            {
+                return "$1$" + string.Join(string.Empty, md5.ComputeHash(Encoding.UTF8.GetBytes(input)).Select(b => b.ToString("x2")));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Since I was not able to log in due to specific characters contained in my password which the deprecated OpenMetaverse.Utils.MD5 function is not able to hash it properly so this pull request fixes it up. By the way I wonder why most local chat messages get capped, I had a look at the Packet and Network source codes and noticed that only UDP sockets were implemented, shouldn't a TCP socket be implemented for chat messages instead?