### PR TITLE
Fix skeleton crash,, add Touch action to Inventory Console

### DIFF
--- a/Radegast/Core/Contexts/ContextActionsManager.cs
+++ b/Radegast/Core/Contexts/ContextActionsManager.cs
@@ -211,7 +211,7 @@ namespace Radegast
         /// </summary>
         /// <param name="strip">The form's menu</param>        
         /// <param name="type">The type it will target</param>
-        /// <param name="obj">the Target ofbject</param>
+        /// <param name="obj">the Target object</param>
         /// <param name="controls">Control to search for extra contributions (like buttons)</param>
         public void GleanContributions(ToolStripDropDown strip, Type type, Object obj, params Control[] controls)
         {

--- a/Radegast/GUI/Consoles/Inventory/InventoryConsole.cs
+++ b/Radegast/GUI/Consoles/Inventory/InventoryConsole.cs
@@ -1529,6 +1529,14 @@ namespace Radegast
                     }
                     ctxInv.Items.Add(ctxItem);
 
+                    if (item.InventoryType == InventoryType.Object && IsAttached(item))
+                    {
+                        ctxItem = new ToolStripMenuItem("Touch", null, OnInvContextClick) { Name = "touch" };
+                        //TODO: add RLV support
+                        if ((attachments[item.UUID].Prim.Flags & PrimFlags.Touch) == 0) ctxItem.Enabled = false;
+                        ctxInv.Items.Add(ctxItem);
+                    }
+
                     if (IsAttached(item) && instance.RLV.AllowDetach(attachments[item.UUID]))
                     {
                         ctxItem =
@@ -1837,6 +1845,18 @@ namespace Radegast
 
                     case "rename_item":
                         invTree.SelectedNode.BeginEdit();
+                        break;
+
+                    case "touch":
+                        lock (attachments[item.UUID])
+                        {
+                            AttachmentInfo aInfo = attachments[item.UUID];
+                            Client.Self.Grab(aInfo.Prim.LocalID, Vector3.Zero, Vector3.Zero, Vector3.Zero, 0,
+                                    Vector3.Zero, Vector3.Zero, Vector3.Zero);
+                            Thread.Sleep(100);
+                            Client.Self.DeGrab(aInfo.Prim.LocalID, Vector3.Zero, Vector3.Zero, 0, Vector3.Zero,
+                                    Vector3.Zero, Vector3.Zero);
+                        }
                         break;
 
                     case "detach":

--- a/Radegast/GUI/Rendering/Rendering.cs
+++ b/Radegast/GUI/Rendering/Rendering.cs
@@ -1668,7 +1668,14 @@ namespace Radegast.Rendering
                 BinBVHAnimationReader bvh;
                 if (skeleton.mAnimationCache.TryGetValue(anim.AnimationID, out bvh))
                 {
-                    skeleton.addanimation(null, tid, bvh, anim.AnimationID);
+                    try
+                    {
+                        skeleton.addanimation(null, tid, bvh, anim.AnimationID);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Log($"Failure in skel.addanimation: {ex.Message}", Helpers.LogLevel.Error);
+                    }
                     continue;
                 }
 


### PR DESCRIPTION
This copies the 'touch' action that Firestorm implement, allowing one to touch object attached to one's avatar from the inventory console even when the 3d view is not active.