### PR TITLE
RAD-70: Cannot click URIs/Links in local chat

### DIFF
--- a/Radegast/app.config
+++ b/Radegast/app.config
@@ -4,6 +4,7 @@
     <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler,log4net" />
   </configSections>
   <runtime>
+    <AppContextSwitchOverrides value="Switch.System.Windows.Forms.DoNotLoadLatestRichEditControl=true" />
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="OpenTK" publicKeyToken="bad199fe84eb3df4" culture="neutral" />


### PR DESCRIPTION
Reverted to the older RichTextBox control. The newer RichTextBox control changed the existing behavior of what gets passed to its 'OnLinkClicked' event so it can no longer be used the way we use it to create pretty links. It also broke the implementation of fldrslt, which is the alternative way of showing pretty links