### PR TITLE
Fix windows build

### DIFF
--- a/Radegast/Radegast.csproj
+++ b/Radegast/Radegast.csproj
@@ -80,7 +80,7 @@
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
-    <PackageReference Include="System.Resources.Extensions" Version="9.0.2" />
+    <PackageReference Include="System.Resources.Extensions" Version="9.0.4" />
     <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />


### PR DESCRIPTION
Fix windows build by updating to a non-broken version of System.Resources.Extensions ( https://github.com/dotnet/runtime/issues/111892 ). The GenerateResourceUsePreserializedResources change causes it to actually utilize the System.Resources.Extensions assembly, but packages 9.01 -> 9.0.3 seem to refer to 9.0.0 instead of their correct versions