### PR TITLE
Temporary hack to resolve 3D scene viewer crash (probably not temporary)

### DIFF
--- a/Radegast/GUI/Rendering/Rendering.cs
+++ b/Radegast/GUI/Rendering/Rendering.cs
@@ -1068,6 +1068,12 @@ namespace Radegast.Rendering
                     }
                     if (item.TextureData == null) { continue; }
 
+                    if (item.ImageType == ImageType.ServerBaked || item.ImageType == ImageType.Baked)
+                    {
+                        // TODO: CoreJ2K can't handle images with more than 4 components and it seems like baked generally has 5.
+                        continue;
+                    }
+
                     var mi = new ManagedImage(J2kImage.FromBytes(item.TextureData));
                     
                     bool hasAlpha = false;


### PR DESCRIPTION
Don't try to load baked images due to the limitations of CoreJ2K. Radegast will crash if it tries to load these textures due to "Invalid number of components: 5"

The viewer is in a really rough state, but I figure not crashing is better than having constant reports of it crashing

The funky textures issue should be resolved by libremetaverse#106