### PR TITLE
(Needs Mac and Linux security review) Clickable link improvements/security

### DIFF
--- a/Radegast/GUI/Dialogs/MainForm.cs
+++ b/Radegast/GUI/Dialogs/MainForm.cs
@@ -34,6 +34,7 @@ using System.Web;
 using Radegast;
 using OpenMetaverse;
 using NetSparkleUpdater.SignatureVerifiers;
+using System.Runtime.InteropServices;
 
 namespace Radegast
 {
@@ -830,11 +831,11 @@ namespace Radegast
                     return false;
                 }
 
-                if (Environment.OSVersion.Platform == PlatformID.Unix)
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
                     System.Diagnostics.Process.Start("xdg-open", uriToOpen.AbsoluteUri);
                 }
-                else if (Environment.OSVersion.Platform == PlatformID.MacOSX)
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
                     System.Diagnostics.Process.Start("open", uriToOpen.AbsoluteUri);
                 }
@@ -842,6 +843,8 @@ namespace Radegast
                 {
                     System.Diagnostics.Process.Start(uriToOpen.AbsoluteUri);
                 }
+
+                return true;
             }
 
             return false;

--- a/Radegast/GUI/Dialogs/MainForm.cs
+++ b/Radegast/GUI/Dialogs/MainForm.cs
@@ -820,8 +820,30 @@ namespace Radegast
             }
             else if (!onlyMap)
             {
-                System.Diagnostics.Process.Start(link);
+                if (!Uri.TryCreate(link, UriKind.Absolute, out Uri uriToOpen))
+                {
+                    return false;
+                }
+
+                if (uriToOpen.Scheme != Uri.UriSchemeHttp && uriToOpen.Scheme != Uri.UriSchemeHttps)
+                {
+                    return false;
+                }
+
+                if (Environment.OSVersion.Platform == PlatformID.Unix)
+                {
+                    System.Diagnostics.Process.Start("xdg-open", link);
+                }
+                else if (Environment.OSVersion.Platform == PlatformID.MacOSX)
+                {
+                    System.Diagnostics.Process.Start("open", link);
+                }
+                else
+                {
+                    System.Diagnostics.Process.Start(link);
+                }
             }
+
             return false;
         }
         #endregion

--- a/Radegast/GUI/Dialogs/MainForm.cs
+++ b/Radegast/GUI/Dialogs/MainForm.cs
@@ -832,15 +832,15 @@ namespace Radegast
 
                 if (Environment.OSVersion.Platform == PlatformID.Unix)
                 {
-                    System.Diagnostics.Process.Start("xdg-open", link);
+                    System.Diagnostics.Process.Start("xdg-open", uriToOpen.AbsoluteUri);
                 }
                 else if (Environment.OSVersion.Platform == PlatformID.MacOSX)
                 {
-                    System.Diagnostics.Process.Start("open", link);
+                    System.Diagnostics.Process.Start("open", uriToOpen.AbsoluteUri);
                 }
                 else
                 {
-                    System.Diagnostics.Process.Start(link);
+                    System.Diagnostics.Process.Start(uriToOpen.AbsoluteUri);
                 }
             }
 

--- a/Radegast/GUI/Dialogs/MainForm.cs
+++ b/Radegast/GUI/Dialogs/MainForm.cs
@@ -831,17 +831,39 @@ namespace Radegast
                     return false;
                 }
 
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                try
                 {
-                    System.Diagnostics.Process.Start("xdg-open", uriToOpen.AbsoluteUri);
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                    {
+                        System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                        {
+                            FileName = "xdg-open",
+                            Arguments = uriToOpen.AbsoluteUri,
+                            UseShellExecute = true
+                        });
+                    }
+                    else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                    {
+                        System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                        {
+                            FileName = "open",
+                            Arguments = uriToOpen.AbsoluteUri,
+                            UseShellExecute = true
+                        });
+                    }
+                    else
+                    {
+                        System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                        {
+                            FileName = uriToOpen.AbsoluteUri,
+                            UseShellExecute = true
+                        });
+                    }
                 }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                catch (Exception ex)
                 {
-                    System.Diagnostics.Process.Start("open", uriToOpen.AbsoluteUri);
-                }
-                else
-                {
-                    System.Diagnostics.Process.Start(uriToOpen.AbsoluteUri);
+                    Logger.Log($"Failed to execute link: {link}", Helpers.LogLevel.Error, instance.Client, ex);
+                    return false;
                 }
 
                 return true;


### PR DESCRIPTION
I don't currently have a MacOS dev machine so I can't test this and don't know the best practice of handling URL's for these two platforms. If links already work correctly, then a lot of this can be reverted. I just couldn't get links to open a browser up on Ubuntu so I assumed the same for MacOS

- Added some sanitization/preventative measures for processing clickable chat URL's
- Linux now uses 'xdg-open' to open url's
- MacOS now uses 'open' to open url's