### PR TITLE
Quick fix for installer path

### DIFF
--- a/Install/RadegastBundle/Bundle.wxs
+++ b/Install/RadegastBundle/Bundle.wxs
@@ -17,7 +17,7 @@
                                               Theme='rtfLargeLicense' />
     </BootstrapperApplication>
 
-    <Variable Name="InstallFolder" Type="string" Value="[ProgramFiles64Folder]$(var.productName)" />
+    <Variable Name="InstallFolder" Type="string" Value="" />
 
     <Chain>
       <PackageGroupRef Id="NetFx48Redist" />
@@ -26,7 +26,7 @@
                   DisplayName="$(var.productName)"
                   Vital="yes"
                   After="NetFx48Redist">
-        <MsiProperty Name="INSTALLFOLDER" Value="[InstallFolder]" />
+        <MsiProperty Name="INSTALLFOLDER" Value="[InstallFolder]" Condition="InstallFolder" />
       </MsiPackage>
     </Chain>
   </Bundle>


### PR DESCRIPTION
This seems to resolve the issue of #81 literal "[Programfiles64folder]Radegast" installation directory.

The downside of this is that no default InstallFolder path is hinted at when the user clicks the custom installation directory. They are just given a blank path they have to manually select