### PR TITLE
Rework outfit handling

### DIFF
--- a/Radegast/Core/ChatTextManager.cs
+++ b/Radegast/Core/ChatTextManager.cs
@@ -262,11 +262,11 @@ namespace Radegast
                     }
                     catch (TimeoutException ex)
                     {
-                        Logger.LogInstance.Error("Timed out running inventory console background task", ex);
+                        Logger.LogInstance.Error("Timed out running RLV command background task", ex);
                     }
                     catch (Exception ex)
                     {
-                        Logger.LogInstance.Error("Exception while running inventory console background task", ex);
+                        Logger.LogInstance.Error("Exception while running RLV command background task", ex);
                     }
                 });
 #if !DEBUG

--- a/Radegast/Core/ChatTextManager.cs
+++ b/Radegast/Core/ChatTextManager.cs
@@ -26,6 +26,7 @@ using System.Drawing;
 using System.Reflection;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Radegast
 {
@@ -250,17 +251,16 @@ namespace Radegast
                 && e.Type == ChatType.OwnerSay
                 && e.Message.StartsWith("@"))
             {
-                ThreadPool.QueueUserWorkItem(sync =>
+                Task.Run(async () =>
                 {
                     try
                     {
-                        using (var cts = new CancellationTokenSource())
+                        using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120)))
                         {
-                            cts.CancelAfter(TimeSpan.FromSeconds(120));
-                            instance.RLV.TryProcessCMD(e, cts.Token).Wait();
+                            await instance.RLV.TryProcessCMD(e, cts.Token);
                         }
                     }
-                    catch (TimeoutException ex)
+                    catch (TaskCanceledException ex)
                     {
                         Logger.LogInstance.Error("Timed out running RLV command background task", ex);
                     }

--- a/Radegast/Core/InitialOutfit.cs
+++ b/Radegast/Core/InitialOutfit.cs
@@ -157,7 +157,7 @@ namespace Radegast
                 .Where(item => item is InventoryWearable || item is InventoryAttachment || item is InventoryObject)
                 .Cast<InventoryItem>().ToList();
 
-            Instance.COF.ReplaceOutfit(newOutfit);
+            Instance.COF.ReplaceOutfit(newClothingFolder).Wait();
             Logger.Log("Initial outfit thread (first login) exiting", Helpers.LogLevel.Debug);
         }
     }

--- a/Radegast/Core/RLV/RLVManager.cs
+++ b/Radegast/Core/RLV/RLVManager.cs
@@ -24,6 +24,8 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
 
@@ -224,7 +226,7 @@ namespace Radegast
             }
         }
 
-        public bool TryProcessCMD(ChatEventArgs e)
+        public async Task<bool> TryProcessCMD(ChatEventArgs e, CancellationToken cancellationToken = default)
         {
             if (!Enabled || !e.Message.StartsWith("@")) return false;
 
@@ -610,10 +612,10 @@ namespace Radegast
                                         if (client.Inventory.Store.Contains(
                                                 CurrentOutfitFolder.GetAttachmentItem(attachment)))
                                         {
-                                            instance.COF.Detach(
+                                            await instance.COF.Detach(
                                                 client.Inventory.Store[
                                                     CurrentOutfitFolder
-                                                        .GetAttachmentItem(attachment)] as InventoryItem).Wait();
+                                                        .GetAttachmentItem(attachment)] as InventoryItem, cancellationToken);
                                         }
                                     }
                                 }
@@ -624,7 +626,7 @@ namespace Radegast
                                     {
                                         var outfit = (from item in folder.Nodes.Values 
                                             where CurrentOutfitFolder.CanBeWorn(item.Data) select (InventoryItem) (item.Data)).ToList();
-                                        instance.COF.RemoveFromOutfit(outfit).Wait();
+                                        await instance.COF.RemoveFromOutfit(outfit, cancellationToken);
                                     }
                                 }
                             }
@@ -638,7 +640,10 @@ namespace Radegast
                                 {
                                     if (client.Inventory.Store.Contains(CurrentOutfitFolder.GetAttachmentItem(attachment)))
                                     {
-                                        instance.COF.Detach(client.Inventory.Store[CurrentOutfitFolder.GetAttachmentItem(attachment)] as InventoryItem).Wait();
+                                        await instance.COF.Detach(
+                                            client.Inventory.Store[CurrentOutfitFolder.GetAttachmentItem(attachment)] as InventoryItem,
+                                            cancellationToken
+                                        );
                                     }
                                 }
                             }
@@ -655,7 +660,7 @@ namespace Radegast
                                     List<InventoryItem> allItems = new List<InventoryItem>();
                                     AllSubfolderWearables(folder, ref allItems);
                                     List<InventoryItem> allSubfolderWorn = allItems.Where(n => CurrentOutfitFolder.CanBeWorn(n)).ToList();
-                                    instance.COF.RemoveFromOutfit(allSubfolderWorn).Wait();
+                                    await instance.COF.RemoveFromOutfit(allSubfolderWorn, cancellationToken);
                                 }
                             }
                         }
@@ -677,7 +682,7 @@ namespace Radegast
                                     {
                                         var outfit = new List<InventoryItem>();
                                         GetAllItems(folder, true, ref outfit);
-                                        instance.COF.RemoveFromOutfit(outfit).Wait();
+                                        await instance.COF.RemoveFromOutfit(outfit, cancellationToken);
                                     }
                                 }
                             }
@@ -693,7 +698,7 @@ namespace Radegast
                                 if (w.Name == rule.Option)
                                 {
                                     var items = instance.COF.GetWornAt(w.Type).Result;
-                                    instance.COF.RemoveFromOutfit(items).Wait();
+                                    await instance.COF.RemoveFromOutfit(items, cancellationToken);
                                 }
                             }
                         }
@@ -723,11 +728,11 @@ namespace Radegast
 
                                     if (rule.Behaviour == "attachover" || rule.Behaviour == "attachallover")
                                     {
-                                        instance.COF.AddToOutfit(outfit, false).Wait();
+                                        await instance.COF.AddToOutfit(outfit, false, cancellationToken);
                                     }
                                     else
                                     {
-                                        instance.COF.AddToOutfit(outfit, true).Wait();
+                                        await instance.COF.AddToOutfit(outfit, true, cancellationToken);
                                     }
                                 }
                             }

--- a/Radegast/Core/RLV/RLVManager.cs
+++ b/Radegast/Core/RLV/RLVManager.cs
@@ -697,7 +697,7 @@ namespace Radegast
                                 var w = RLVWearables.Find(a => a.Name == rule.Option);
                                 if (w.Name == rule.Option)
                                 {
-                                    var items = instance.COF.GetWornAt(w.Type).Result;
+                                    var items = await instance.COF.GetWornAt(w.Type);
                                     await instance.COF.RemoveFromOutfit(items, cancellationToken);
                                 }
                             }

--- a/Radegast/Core/RLV/RLVManager.cs
+++ b/Radegast/Core/RLV/RLVManager.cs
@@ -613,7 +613,7 @@ namespace Radegast
                                             instance.COF.Detach(
                                                 client.Inventory.Store[
                                                     CurrentOutfitFolder
-                                                        .GetAttachmentItem(attachment)] as InventoryItem);
+                                                        .GetAttachmentItem(attachment)] as InventoryItem).Wait();
                                         }
                                     }
                                 }
@@ -624,7 +624,7 @@ namespace Radegast
                                     {
                                         var outfit = (from item in folder.Nodes.Values 
                                             where CurrentOutfitFolder.CanBeWorn(item.Data) select (InventoryItem) (item.Data)).ToList();
-                                        instance.COF.RemoveFromOutfit(outfit);
+                                        instance.COF.RemoveFromOutfit(outfit).Wait();
                                     }
                                 }
                             }
@@ -638,7 +638,7 @@ namespace Radegast
                                 {
                                     if (client.Inventory.Store.Contains(CurrentOutfitFolder.GetAttachmentItem(attachment)))
                                     {
-                                        instance.COF.Detach(client.Inventory.Store[CurrentOutfitFolder.GetAttachmentItem(attachment)] as InventoryItem);
+                                        instance.COF.Detach(client.Inventory.Store[CurrentOutfitFolder.GetAttachmentItem(attachment)] as InventoryItem).Wait();
                                     }
                                 }
                             }
@@ -655,7 +655,7 @@ namespace Radegast
                                     List<InventoryItem> allItems = new List<InventoryItem>();
                                     AllSubfolderWearables(folder, ref allItems);
                                     List<InventoryItem> allSubfolderWorn = allItems.Where(n => CurrentOutfitFolder.CanBeWorn(n)).ToList();
-                                    instance.COF.RemoveFromOutfit(allSubfolderWorn);
+                                    instance.COF.RemoveFromOutfit(allSubfolderWorn).Wait();
                                 }
                             }
                         }
@@ -677,7 +677,7 @@ namespace Radegast
                                     {
                                         var outfit = new List<InventoryItem>();
                                         GetAllItems(folder, true, ref outfit);
-                                        instance.COF.RemoveFromOutfit(outfit);
+                                        instance.COF.RemoveFromOutfit(outfit).Wait();
                                     }
                                 }
                             }
@@ -692,8 +692,8 @@ namespace Radegast
                                 var w = RLVWearables.Find(a => a.Name == rule.Option);
                                 if (w.Name == rule.Option)
                                 {
-                                    var items = instance.COF.GetWornAt(w.Type);
-                                    instance.COF.RemoveFromOutfit(items);
+                                    var items = instance.COF.GetWornAt(w.Type).Result;
+                                    instance.COF.RemoveFromOutfit(items).Wait();
                                 }
                             }
                         }
@@ -723,11 +723,11 @@ namespace Radegast
 
                                     if (rule.Behaviour == "attachover" || rule.Behaviour == "attachallover")
                                     {
-                                        instance.COF.AddToOutfit(outfit, false);
+                                        instance.COF.AddToOutfit(outfit, false).Wait();
                                     }
                                     else
                                     {
-                                        instance.COF.AddToOutfit(outfit, true);
+                                        instance.COF.AddToOutfit(outfit, true).Wait();
                                     }
                                 }
                             }

--- a/Radegast/GUI/Consoles/Inventory/CurrentOutfitFolder.cs
+++ b/Radegast/GUI/Consoles/Inventory/CurrentOutfitFolder.cs
@@ -737,26 +737,6 @@ namespace Radegast
             await AddToOutfit(new List<InventoryItem>(1) { item }, replace, cancellationToken);
         }
 
-        private async Task<InventoryBase> FollowItemLink(InventoryItem itemLink, CancellationToken cancellationToken = default)
-        {
-            if (!itemLink.IsLink())
-            {
-                return itemLink;
-            }
-
-            if (itemLink.AssetUUID == UUID.Zero)
-            {
-                return itemLink;
-            }
-
-            if (Client.Inventory.Store.TryGetValue(itemLink.AssetUUID, out var remoteInventoryItem))
-            {
-                return remoteInventoryItem;
-            }
-
-            return await Client.Inventory.FetchItemHttpAsync(itemLink.AssetUUID, itemLink.OwnerID, cancellationToken);
-        }
-
         private async Task<InventoryBase> FetchParent(InventoryBase item, CancellationToken cancellationToken = default)
         {
             if (!Client.Inventory.Store.TryGetNodeFor(item.ParentUUID, out var parent))

--- a/Radegast/GUI/Consoles/Inventory/InventoryConsole.Designer.cs
+++ b/Radegast/GUI/Consoles/Inventory/InventoryConsole.Designer.cs
@@ -47,8 +47,12 @@ namespace Radegast
         {
             if (disposing && (components != null))
             {
-                inventoryUpdateCancelToken.Cancel();
-                inventoryUpdateCancelToken.Dispose();
+                if(inventoryUpdateCancelToken != null)
+                {
+                    inventoryUpdateCancelToken.Cancel();
+                    inventoryUpdateCancelToken.Dispose();
+                    inventoryUpdateCancelToken = null;
+                }
 
                 if (_EditTimer != null)
                 {

--- a/Radegast/GUI/Consoles/Inventory/InventoryConsole.cs
+++ b/Radegast/GUI/Consoles/Inventory/InventoryConsole.cs
@@ -964,11 +964,11 @@ namespace Radegast
                 case AssetType.Object:
                     if (IsAttached(item))
                     {
-                        instance.COF.Detach(item);
+                        instance.COF.Detach(item).Wait();
                     }
                     else
                     {
-                        instance.COF.Attach(item, AttachmentPoint.Default, true);
+                        instance.COF.Attach(item, AttachmentPoint.Default, true).Wait();
                     }
                     break;
 
@@ -978,12 +978,12 @@ namespace Radegast
                     {
                         if (item.AssetType == AssetType.Clothing)
                         {
-                            instance.COF.RemoveFromOutfit(item);
+                            instance.COF.RemoveFromOutfit(item).Wait();
                         }
                     }
                     else
                     {
-                        instance.COF.AddToOutfit(item, true);
+                        instance.COF.AddToOutfit(item, true).Wait();
                     }
                     break;
             }
@@ -1626,17 +1626,35 @@ namespace Radegast
                         });
                         break;
                     case "outfit_add":
-                        List<InventoryItem> addToOutfit = GetInventoryItemsForOutFit(folder);
+                        var addToOutfit = GetInventoryItemsForOutFit(folder);
                         appearanceWasBusy = Client.Appearance.ManagerBusy;
-                        instance.COF.AddToOutfit(addToOutfit, false);
-                        UpdateWornLabels();
+
+                        ThreadPool.QueueUserWorkItem(sync =>
+                        {
+                            using (var cts = new CancellationTokenSource())
+                            {
+                                cts.CancelAfter(TimeSpan.FromSeconds(30));
+                                instance.COF.AddToOutfit(addToOutfit, false).Wait();
+                            }
+
+                            UpdateWornLabels();
+                        });
                         break;
 
                     case "outfit_take_off":
-                        List<InventoryItem> removeFromOutfit = GetInventoryItemsForOutFit(folder);
+                        var removeFromOutfit = GetInventoryItemsForOutFit(folder);
                         appearanceWasBusy = Client.Appearance.ManagerBusy;
-                        instance.COF.RemoveFromOutfit(removeFromOutfit);
-                        UpdateWornLabels();
+
+                        ThreadPool.QueueUserWorkItem(sync =>
+                        {
+                            using (var cts = new CancellationTokenSource())
+                            {
+                                cts.CancelAfter(TimeSpan.FromSeconds(30));
+                                instance.COF.RemoveFromOutfit(removeFromOutfit).Wait();
+                            }
+
+                            UpdateWornLabels();
+                        });
                         break;
                 }
                 #endregion
@@ -1709,21 +1727,21 @@ namespace Radegast
                         break;
 
                     case "detach":
-                        instance.COF.Detach(item);
+                        instance.COF.Detach(item).Wait();
                         invTree.SelectedNode.Text = ItemLabel(item, false);
                         break;
 
                     case "wear_attachment":
-                        instance.COF.Attach(item, AttachmentPoint.Default, true);
+                        instance.COF.Attach(item, AttachmentPoint.Default, true).Wait();
                         break;
 
                     case "wear_attachment_add":
-                        instance.COF.Attach(item, AttachmentPoint.Default, false);
+                        instance.COF.Attach(item, AttachmentPoint.Default, false).Wait();
                         break;
 
                     case "attach_to":
                         AttachmentPoint pt = (AttachmentPoint)((ToolStripMenuItem)sender).Tag;
-                        instance.COF.Attach(item, pt, true);
+                        instance.COF.Attach(item, pt, true).Wait();
                         break;
 
                     case "edit_script":
@@ -1737,19 +1755,19 @@ namespace Radegast
 
                     case "wearable_take_off":
                         appearanceWasBusy = Client.Appearance.ManagerBusy;
-                        instance.COF.RemoveFromOutfit(item);
+                        instance.COF.RemoveFromOutfit(item).Wait();
                         invTree.SelectedNode.Text = ItemLabel(item, false);
                         break;
 
                     case "wearable_wear":
                         appearanceWasBusy = Client.Appearance.ManagerBusy;
-                        instance.COF.AddToOutfit(item, true);
+                        instance.COF.AddToOutfit(item, true).Wait();
                         invTree.SelectedNode.Text = ItemLabel(item, false);
                         break;
 
                     case "wearable_add":
                         appearanceWasBusy = Client.Appearance.ManagerBusy;
-                        instance.COF.AddToOutfit(item, false);
+                        instance.COF.AddToOutfit(item, false).Wait();
                         invTree.SelectedNode.Text = ItemLabel(item, false);
                         break;
 

--- a/Radegast/GUI/Consoles/Inventory/InventoryConsole.cs
+++ b/Radegast/GUI/Consoles/Inventory/InventoryConsole.cs
@@ -18,20 +18,21 @@
  * along with this program.If not, see<https://www.gnu.org/licenses/>.
  */
 
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Globalization;
-using System.Linq;
-using System.Windows.Forms;
-using System.Threading;
-using System.Threading.Tasks;
 using CommandLine;
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
 using Radegast.Core;
 using Radegast.WinForms;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
 
 namespace Radegast
 {
@@ -55,8 +56,7 @@ namespace Radegast
         private readonly Dictionary<UUID, TreeNode> UUID2NodeCache = new Dictionary<UUID, TreeNode>();
         private bool appearanceWasBusy;
         private InvNodeSorter sorter;
-        private readonly List<UUID> QueuedFolders = new List<UUID>();
-        private readonly Dictionary<UUID, int> FolderFetchRetries = new Dictionary<UUID, int>();
+        private readonly ConcurrentDictionary<UUID, int> QueuedFoldersNeedingUpdate = new ConcurrentDictionary<UUID, int>();
         private readonly AutoResetEvent trashCreated = new AutoResetEvent(false);
         private Task inventoryUpdateTask;
         private CancellationTokenSource inventoryUpdateCancelToken;
@@ -575,70 +575,72 @@ namespace Radegast
 
         private void TraverseAndQueueNodes(InventoryNode start)
         {
-            bool has_items = start.Nodes.Values.Any(node => node.Data is InventoryItem);
-
-            if (!has_items || start.NeedsUpdate)
+            if (start.NeedsUpdate)
             {
-                lock (QueuedFolders)
-                {
-                    lock (FolderFetchRetries)
-                    {
-                        int retries = 0;
-                        FolderFetchRetries.TryGetValue(start.Data.UUID, out retries);
-                        if (retries < 3)
-                        {
-                            if (!QueuedFolders.Contains(start.Data.UUID))
-                            {
-                                QueuedFolders.Add(start.Data.UUID);
-                            }
-                        }
-                        FolderFetchRetries[start.Data.UUID] = retries + 1;
-                    }
-                }
+                QueuedFoldersNeedingUpdate.TryAdd(start.Data.UUID, 0);
             }
 
-            foreach (var item in Inventory.GetContents((InventoryFolder)start.Data).OfType<InventoryFolder>())
+            foreach (var item in Client.Inventory.Store.GetContents((InventoryFolder)start.Data).OfType<InventoryFolder>())
             {
-                TraverseAndQueueNodes(Inventory.GetNodeFor(item.UUID));
+                TraverseAndQueueNodes(Client.Inventory.Store.GetNodeFor(item.UUID));
             }
         }
 
-        private void TraverseNodes(InventoryNode start)
+        private void Inventory_FolderUpdated(object sender, FolderUpdatedEventArgs e)
         {
-            bool has_items = start.Nodes.Values.Any(node => node.Data is InventoryItem);
-
-            if (!has_items || start.NeedsUpdate)
+            if (e.Success)
             {
-                InventoryFolder f = (InventoryFolder)start.Data;
-                AutoResetEvent gotFolderEvent = new AutoResetEvent(false);
-                bool success = false;
-
-                void FolderUpdatedCB(object sender, FolderUpdatedEventArgs ea)
-                {
-                    if (f.UUID != ea.FolderID) { return; }
-                    if (((InventoryFolder) Inventory[ea.FolderID]).DescendentCount >
-                        Inventory.GetNodeFor(ea.FolderID).Nodes.Count) { return; }
-
-                    success = true;
-                    gotFolderEvent.Set();
-                }
-
-                Client.Inventory.FolderUpdated += FolderUpdatedCB;
-                FetchFolder(f.UUID, f.OwnerID, true);
-                gotFolderEvent.WaitOne(30 * 1000, false);
-                Client.Inventory.FolderUpdated -= FolderUpdatedCB;
-
-                if (!success)
-                {
-                    Logger.Log(
-                        $"Failed fetching folder {f.Name}, got {Inventory.GetNodeFor(f.UUID).Nodes.Count} items out of {Inventory[f.UUID].Cast<InventoryFolder>().DescendentCount}",
-                        Helpers.LogLevel.Error, Client);
-                }
+                QueuedFoldersNeedingUpdate.TryRemove(e.FolderID, out var _);
+                return;
             }
 
-            foreach (var item in Inventory.GetContents((InventoryFolder)start.Data).OfType<InventoryFolder>())
+            if (!QueuedFoldersNeedingUpdate.TryGetValue(e.FolderID, out var retries))
             {
-                TraverseNodes(Inventory.GetNodeFor(item.UUID));
+                return;
+            }
+
+            if (retries > 3)
+            {
+                QueuedFoldersNeedingUpdate.TryRemove(e.FolderID, out var _);
+            }
+            else
+            {
+                QueuedFoldersNeedingUpdate.TryUpdate(e.FolderID, retries + 1, retries);
+            }
+        }
+
+        private async Task FetchQueuedFolders()
+        {
+            Client.Inventory.FolderUpdated += Inventory_FolderUpdated;
+
+            try
+            {
+                QueuedFoldersNeedingUpdate.Clear();
+                TraverseAndQueueNodes(Client.Inventory.Store.RootNode);
+
+                while (!QueuedFoldersNeedingUpdate.IsEmpty)
+                {
+                    var folderKeys = QueuedFoldersNeedingUpdate.Keys.ToList();
+                    var tasks = folderKeys
+                        .Select(folderKey =>
+                        {
+                            return Client.Inventory.RequestFolderContents(
+                                folderKey,
+                                Client.Self.AgentID,
+                                true,
+                                true,
+                                InventorySortOrder.ByDate,
+                                inventoryUpdateCancelToken.Token
+                            );
+                        });
+
+                    await Task.WhenAll(tasks);
+                    TraverseAndQueueNodes(Client.Inventory.Store.RootNode);
+                }
+            }
+            finally
+            {
+                Client.Inventory.FolderUpdated -= Inventory_FolderUpdated;
             }
         }
 
@@ -654,28 +656,9 @@ namespace Radegast
             TreeUpdateInProgress = true;
             TreeUpdateTimer.Start();
 
-            lock (FolderFetchRetries)
-            {
-                FolderFetchRetries.Clear();
-            }
             GestureManager.Instance.BeginMonitoring();
-            do
-            {
-                lock (QueuedFolders)
-                {
-                    QueuedFolders.Clear();
-                }
-                TraverseAndQueueNodes(Inventory.RootNode);
-                if (QueuedFolders.Count == 0) { break; }
-                //Logger.DebugLog($"Queued {QueuedFolders.Count} folders for update");
 
-                Parallel.ForEach(QueuedFolders, folderID =>
-                {
-                    _ = Client.Inventory.RequestFolderContents(folderID, Client.Self.AgentID, 
-                        true, true, InventorySortOrder.ByDate, inventoryUpdateCancelToken.Token).Result;
-                });
-            }
-            while (QueuedFolders.Count > 0);
+            FetchQueuedFolders().Wait();
 
             TreeUpdateTimer.Stop();
             if (IsHandleCreated)
@@ -716,12 +699,10 @@ namespace Radegast
 
             if (!instance.MonoRuntime || IsHandleCreated)
                 Invoke(new MethodInvoker(() =>
-                    {
-                        invTree.Sort();
-                    }
+                {
+                    invTree.Sort();
+                }
             ));
-
-
         }
 
         public void ReloadInventory()

--- a/Radegast/GUI/Consoles/Inventory/InventoryConsole.cs
+++ b/Radegast/GUI/Consoles/Inventory/InventoryConsole.cs
@@ -1496,7 +1496,7 @@ namespace Radegast
             }
         }
 
-        private void RunBackgroundTask(Action<CancellationToken> work, Action uiCallback = null, int timeoutSeconds = 10)
+        private void RunBackgroundTask(Action<CancellationToken> work, Action uiCallback = null, int timeoutSeconds = 60)
         {
             ThreadPool.QueueUserWorkItem(sync =>
             {

--- a/Radegast/GUI/Consoles/ObjectsConsole.cs
+++ b/Radegast/GUI/Consoles/ObjectsConsole.cs
@@ -965,7 +965,25 @@ namespace Radegast
 
             if (client.Inventory.Store.Contains(toDetach))
             {
-                instance.COF.Detach(client.Inventory.Store[toDetach] as InventoryItem).Wait();
+                ThreadPool.QueueUserWorkItem(sync =>
+                {
+                    try
+                    {
+                        using (var cts = new CancellationTokenSource())
+                        {
+                            cts.CancelAfter(TimeSpan.FromSeconds(60));
+                            instance.COF.Detach(client.Inventory.Store[toDetach] as InventoryItem).Wait();
+                        }
+                    }
+                    catch (TimeoutException ex)
+                    {
+                        Logger.LogInstance.Error("Timed out while detaching object from object console", ex);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogInstance.Error("Exception while detaching object from object console", ex);
+                    }
+                });
             }
         }
 

--- a/Radegast/GUI/Consoles/ObjectsConsole.cs
+++ b/Radegast/GUI/Consoles/ObjectsConsole.cs
@@ -964,7 +964,7 @@ namespace Radegast
 
             if (client.Inventory.Store.Contains(toDetach))
             {
-                instance.COF.Detach(client.Inventory.Store[toDetach] as InventoryItem);
+                instance.COF.Detach(client.Inventory.Store[toDetach] as InventoryItem).Wait();
             }
         }
 


### PR DESCRIPTION
I have a feeling a lot of this outfit related stuff (attach, detach, replace outfit, remove outfit, etc) should happen in libremetaverse instead of Radegast in the long run

- Large portions of CurrentOutfitFolder logic rewritten to be more robust and in line with how the current client functions
- CurrentOutfitFolder mostly all async now with optional CancellationToken support
- Fix rare crash in InventoryConsole destruction
- Simplified inventory console inventory node traversal
- RLV commands are no longer executed on the main thread
- GestureManager.Guestures is now a ConcurrentDictionary
- Won't build yet until next libremetaverse version (v2.3.2+) is published
