### PR TITLE
mention color should be yellow, not pink

### DIFF
--- a/Radegast/Core/Settings.cs
+++ b/Radegast/Core/Settings.cs
@@ -140,7 +140,7 @@ namespace Radegast
             {"MentionMe", new FontSetting {
                 Name = "MentionMe",
                 ForeColor = SystemColors.ControlText,
-                BackColor = Color.Pink,
+                BackColor = Color.Yellow,
                 Font = FontSetting.DefaultFont,
             }},
             {"MentionOthers", new FontSetting {


### PR DESCRIPTION
Sneaking this one in before it gets written to everyone's font settings and would require manual changes to fix