### PR TITLE
Added WearableTexture component to preview/display wearables

### DIFF
--- a/Radegast/GUI/Consoles/Assets/WearableTextures.Designer.cs
+++ b/Radegast/GUI/Consoles/Assets/WearableTextures.Designer.cs
@@ -1,0 +1,118 @@
+/*
+ * Radegast Metaverse Client
+ * Copyright(c) 2009-2014, Radegast Development Team
+ * Copyright(c) 2016-2025, Sjofn, LLC
+ * All rights reserved.
+ *
+ * Radegast is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.If not, see<https://www.gnu.org/licenses/>.
+ */
+
+namespace Radegast
+{
+    partial class WearableTextures
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null)) {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.label1 = new System.Windows.Forms.Label();
+            this.lblName = new System.Windows.Forms.Label();
+            this.pnlImages = new System.Windows.Forms.Panel();
+            this.pnlTop = new System.Windows.Forms.Panel();
+            this.pnlTop.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(7, 14);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(102, 13);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "Getting textures for: ";
+            // 
+            // lblName
+            // 
+            this.lblName.AutoSize = true;
+            this.lblName.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblName.Location = new System.Drawing.Point(115, 14);
+            this.lblName.Name = "lblName";
+            this.lblName.Size = new System.Drawing.Size(37, 13);
+            this.lblName.TabIndex = 0;
+            this.lblName.Text = "name";
+            // 
+            // pnlImages
+            // 
+            this.pnlImages.AutoScroll = true;
+            this.pnlImages.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.pnlImages.Location = new System.Drawing.Point(0, 41);
+            this.pnlImages.MaximumSize = new System.Drawing.Size(5000, 0);
+            this.pnlImages.Name = "pnlImages";
+            this.pnlImages.Size = new System.Drawing.Size(489, 351);
+            this.pnlImages.TabIndex = 1;
+            // 
+            // pnlTop
+            // 
+            this.pnlTop.Controls.Add(this.label1);
+            this.pnlTop.Controls.Add(this.lblName);
+            this.pnlTop.Dock = System.Windows.Forms.DockStyle.Top;
+            this.pnlTop.Location = new System.Drawing.Point(0, 0);
+            this.pnlTop.Name = "pnlTop";
+            this.pnlTop.Size = new System.Drawing.Size(489, 41);
+            this.pnlTop.TabIndex = 2;
+            // 
+            // OutfitTextures
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.pnlImages);
+            this.Controls.Add(this.pnlTop);
+            this.Name = "OutfitTextures";
+            this.Size = new System.Drawing.Size(489, 392);
+            this.pnlTop.ResumeLayout(false);
+            this.pnlTop.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        public System.Windows.Forms.Label label1;
+        public System.Windows.Forms.Label lblName;
+        public System.Windows.Forms.Panel pnlImages;
+        public System.Windows.Forms.Panel pnlTop;
+
+    }
+}

--- a/Radegast/GUI/Consoles/Assets/WearableTextures.cs
+++ b/Radegast/GUI/Consoles/Assets/WearableTextures.cs
@@ -1,0 +1,102 @@
+/*
+ * Radegast Metaverse Client
+ * Copyright(c) 2009-2014, Radegast Development Team
+ * Copyright(c) 2016-2025, Sjofn, LLC
+ * All rights reserved.
+ *
+ * Radegast is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.If not, see<https://www.gnu.org/licenses/>.
+ */
+
+using OpenMetaverse;
+using OpenMetaverse.Assets;
+using System.Windows.Forms;
+
+namespace Radegast
+{
+    public partial class WearableTextures : UserControl
+    {
+        private readonly RadegastInstance instance;
+        private readonly InventoryWearable item;
+        private AssetWearable wearable;
+        private GridClient Client => instance.Client;
+
+        public WearableTextures(RadegastInstance instance, InventoryWearable item)
+        {
+            InitializeComponent();
+
+            this.instance = instance;
+            this.item = item;
+
+            if (item != null)
+            {
+                Client.Assets.RequestInventoryAsset(item, true, UUID.Random(), Assets_OnAssetReceived);
+            }
+        }
+
+        private void Assets_OnAssetReceived(AssetDownload transfer, Asset asset)
+        {
+            if (!transfer.Success || !(asset.AssetType == AssetType.Clothing || asset.AssetType == AssetType.Bodypart))
+            {
+                return;
+            }
+
+            asset.Decode();
+            wearable = (AssetWearable)asset;
+
+            GetTextures();
+        }
+
+        public void GetTextures()
+        {
+            if (wearable == null)
+            {
+                return;
+            }
+
+            if (InvokeRequired)
+            {
+                if (!instance.MonoRuntime || IsHandleCreated)
+                {
+                    BeginInvoke(new MethodInvoker(GetTextures));
+                }
+
+                return;
+            }
+
+            lblName.Text = item.Name;
+
+            foreach (var texture in wearable.Textures)
+            {
+                AvatarTextureIndex index = texture.Key;
+                UUID uuid = texture.Value;
+
+                if (uuid != UUID.Zero && uuid != AppearanceManager.DEFAULT_AVATAR_TEXTURE)
+                {
+                    SLImageHandler img = new SLImageHandler(instance, uuid, index.ToString());
+
+                    GroupBox gbx = new GroupBox
+                    {
+                        Dock = DockStyle.Top,
+                        Text = img.Text,
+                        Height = 225
+                    };
+
+                    img.Dock = DockStyle.Fill;
+                    gbx.Controls.Add(img);
+                    pnlImages.Controls.Add(gbx);
+                }
+            }
+        }
+    }
+}

--- a/Radegast/GUI/Consoles/Assets/WearableTextures.resx
+++ b/Radegast/GUI/Consoles/Assets/WearableTextures.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Radegast/GUI/Consoles/Inventory/InventoryConsole.cs
+++ b/Radegast/GUI/Consoles/Inventory/InventoryConsole.cs
@@ -3,17 +3,17 @@
  * Copyright(c) 2009-2014, Radegast Development Team
  * Copyright(c) 2016-2025, Sjofn, LLC
  * All rights reserved.
- *  
+ *
  * Radegast is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.If not, see<https://www.gnu.org/licenses/>.
  */
@@ -229,7 +229,7 @@ namespace Radegast
 
         private void Inventory_InventoryObjectAdded(object sender, InventoryObjectAddedEventArgs e)
         {
-            if (e.Obj is InventoryFolder folder 
+            if (e.Obj is InventoryFolder folder
                 && folder.PreferredType == FolderType.Trash)
             {
                 trashCreated.Set();
@@ -723,7 +723,7 @@ namespace Radegast
             invRootNode = AddDir(null, Inventory.RootFolder);
             Inventory.RootNode.NeedsUpdate = true;
 
-            Task inventoryUpdateTask = Task.Factory.StartNew(StartTraverseNodes, 
+            Task inventoryUpdateTask = Task.Factory.StartNew(StartTraverseNodes,
                 inventoryUpdateCancelToken.Token, TaskCreationOptions.LongRunning, TaskScheduler.Current);
 
             invRootNode.Expand();
@@ -860,6 +860,13 @@ namespace Radegast
                     pnlDetail.Controls.Add(gesture);
                     break;
 
+                case AssetType.Bodypart:
+                case AssetType.Clothing:
+                    WearableTextures wearable = new WearableTextures(instance, (InventoryWearable)item);
+                    wearable.Dock = DockStyle.Fill;
+                    pnlDetail.Controls.Add(wearable);
+                    break;
+
             }
 
             tabsInventory.SelectedTab = tabDetail;
@@ -985,7 +992,7 @@ namespace Radegast
                     fetchedFolders.Add(folderID);
                 }
 
-                Task task = Client.Inventory.RequestFolderContents(folderID, ownerID, 
+                Task task = Client.Inventory.RequestFolderContents(folderID, ownerID,
                     true, true, InventorySortOrder.ByDate, inventoryUpdateCancelToken.Token);
             }
         }
@@ -1008,7 +1015,7 @@ namespace Radegast
 
         public InventoryItem AttachmentAt(AttachmentPoint point)
         {
-            return (from attachment in Client.Appearance.GetAttachmentsByAttachmentPoint() 
+            return (from attachment in Client.Appearance.GetAttachmentsByAttachmentPoint()
                 where attachment.Key == point select attachment.Value.First()).FirstOrDefault();
         }
 
@@ -1354,7 +1361,7 @@ namespace Radegast
                         ctxItem = new ToolStripMenuItem("Touch", null, OnInvContextClick) { Name = "touch" };
                         //TODO: add RLV support
                         var kvp = Client.Network.CurrentSim.ObjectsPrimitives.FirstOrDefault(
-                            p => p.Value.ParentID == Client.Self.LocalID 
+                            p => p.Value.ParentID == Client.Self.LocalID
                                  && CurrentOutfitFolder.GetAttachmentItemID(p.Value) == item.UUID);
                         if (kvp.Value != null)
                         {
@@ -1468,7 +1475,7 @@ namespace Radegast
                                     ctxInv.Items.Add(ctxItem);
                                     break;
                             }
-                            
+
                         }
                     }
 
@@ -1710,16 +1717,16 @@ namespace Radegast
 
                     case "touch":
                         var kvp = Client.Network.CurrentSim.ObjectsPrimitives.FirstOrDefault(
-                            p => p.Value.ParentID == Client.Self.LocalID 
+                            p => p.Value.ParentID == Client.Self.LocalID
                                  && CurrentOutfitFolder.GetAttachmentItemID(p.Value) == item.UUID);
                         if (kvp.Value != null)
                         {
                             var attached = kvp.Value;
-                            Client.Self.Grab(attached.LocalID, 
+                            Client.Self.Grab(attached.LocalID,
                                 Vector3.Zero, Vector3.Zero, Vector3.Zero, 0,
                                 Vector3.Zero, Vector3.Zero, Vector3.Zero);
                             Thread.Sleep(100);
-                            Client.Self.DeGrab(attached.LocalID, Vector3.Zero, Vector3.Zero, 0, 
+                            Client.Self.DeGrab(attached.LocalID, Vector3.Zero, Vector3.Zero, 0,
                                 Vector3.Zero, Vector3.Zero, Vector3.Zero);
                         }
                         break;
@@ -2334,8 +2341,8 @@ namespace Radegast
                     }
 
                     if (cbSrchWorn.Checked && add &&
-                        !(it.InventoryType == InventoryType.Wearable && Client.Appearance.IsItemWorn(it.ActualUUID) 
-                          || (it.InventoryType == InventoryType.Attachment 
+                        !(it.InventoryType == InventoryType.Wearable && Client.Appearance.IsItemWorn(it.ActualUUID)
+                          || (it.InventoryType == InventoryType.Attachment
                               || it.InventoryType == InventoryType.Object) && IsAttached(it)))
                     {
                         add = false;


### PR DESCRIPTION
A thing that bothered me for a long while and I had in my custom Radegast Client for years...

It's a Inventory extension/component which displays wearables (Skins, Alphas, Legacy-Layer clothing), Tattoos and stuff) in a preview. It was always bothersome not to see which wearable looked like before putting it on. 