### PR TITLE
Fixes an issue where group member list gets override when another group info opens

### DIFF
--- a/Radegast/GUI/Consoles/GroupDetails.cs
+++ b/Radegast/GUI/Consoles/GroupDetails.cs
@@ -421,6 +421,7 @@ namespace Radegast
 
         void Groups_GroupMembersReply(object sender, GroupMembersReplyEventArgs e)
         {
+            if (group.ID != e.GroupID) return;
             if (InvokeRequired)
             {
                 BeginInvoke(new MethodInvoker(() => Groups_GroupMembersReply(sender, e)));


### PR DESCRIPTION
Fix for an old annoyance with goup info and list of members