### PR TITLE
Fix "go object ObjectName" command

### DIFF
--- a/Radegast/Core/Commands/GoCommand.cs
+++ b/Radegast/Core/Commands/GoCommand.cs
@@ -210,7 +210,7 @@ Examples:
                     Objects = (ObjectsConsole)TC.Tabs["objects"].Control;
                     var target = Objects.GetObjects().FirstOrDefault(
                         prim => prim.Properties != null
-                                && prim.Properties.Name.IndexOf(cmd, StringComparison.OrdinalIgnoreCase) >= 0);
+                                && prim.Properties.Name.IndexOf(subarg, StringComparison.OrdinalIgnoreCase) >= 0);
                     if (target == null)
                     {
                         WriteLine("Could not find '{0}' nearby", subarg);


### PR DESCRIPTION
"//go object objectname" was looking for object named "object objectname" isntead of the actual object name