### PR TITLE
Sending friend reqeusts is a much more verbose process now and should hopefully be more screen reader friendly

### DIFF
--- a/Radegast/GUI/Dialogs/Profile.cs
+++ b/Radegast/GUI/Dialogs/Profile.cs
@@ -640,6 +640,17 @@ namespace Radegast
         private void btnFriend_Click(object sender, EventArgs e)
         {
             Client.Friends.OfferFriendship(AgentID);
+            this.btnFriend.Enabled = false;
+            this.btnFriend.Text = "Sent Request";
+
+            var message = $"You have offered friendship to {fullName}.";
+
+            if (FriendsConsole.TryFindIMTab(Instance, AgentID, out var console))
+            {
+                console.TextManager.DisplayNotification(message);
+            }
+
+            Instance.TabConsole.DisplayNotificationInChat(message);
         }
 
         private void btnIM_Click(object sender, EventArgs e)


### PR DESCRIPTION
Should resolve https://github.com/cinderblocks/radegast/issues/132

* Added "You have offered friendship to ..." and "... accepted your friendship offer" notifications in the main chat window and relevant IM chat window (if available).
* The 'Add friend' button in the profile window now becomes disabled and has its text updated to "Sent Request" when a request is sent. This is temporary and is reset to  'Add Friend' whenever the profile window is closed and re-opened